### PR TITLE
feat: update to Minecraft 1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ PowerNBT.iml
 target
 out
 doc
+.classpath
+.settings/
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
         <java-version>1.6</java-version>
 
-        <bukkit-version>1.12-R0.1-SNAPSHOT</bukkit-version>
-        <spigot-version>1.12-R0.1-SNAPSHOT</spigot-version>
+        <bukkit-version>1.12.1-R0.1-SNAPSHOT</bukkit-version>
+        <spigot-version>1.12.1-R0.1-SNAPSHOT</spigot-version>
 
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/dpohvar/powernbt/command/action/Argument.java
+++ b/src/main/java/me/dpohvar/powernbt/command/action/Argument.java
@@ -9,6 +9,7 @@ import me.dpohvar.powernbt.utils.NBTQuery;
 import me.dpohvar.powernbt.utils.StringParser;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
@@ -110,7 +111,7 @@ public class Argument {
         if (object.equals("block") || object.equals("b")) {
             if (!(caller.getOwner() instanceof Player)) throw new RuntimeException(plugin.translate("error_noplayer"));
             //noinspection deprecation
-            return new NBTContainerBlock(((Player) caller.getOwner()).getTargetBlock((HashSet<Byte>)null, 128));
+            return new NBTContainerBlock(((Player) caller.getOwner()).getTargetBlock((Set<Material>)null, 128));
         }
         if (object.equals("chunk")) {
             CommandSender owner = caller.getOwner();

--- a/src/main/java/me/dpohvar/powernbt/utils/NBTBlockUtils.java
+++ b/src/main/java/me/dpohvar/powernbt/utils/NBTBlockUtils.java
@@ -38,7 +38,7 @@ public final class NBTBlockUtils {
     );
     private RefMethod write = classTileEntity.findMethod( new MethodCondition()
                     .withTypes("{nms}.NBTTagCompound, {nm}.nbt.NBTTagCompound, {NBTTagCompound}")
-                    .withSuffix("a")
+                    .withSuffix("load")
     );
 
     /**


### PR DESCRIPTION
This PR updates the plugin to Minecraft 1.12.1.  
The deprecated `getTargetBlock` method has been replaced with the proper new one and the tile entity method was changed from `a` to `load`

Additionally I've added eclipse files to the `.gitignore`